### PR TITLE
fix: add missing header class

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,7 +14,7 @@ function getCurrentProjectId() {
 }
 
 function getCurrentHeader() {
-  return document.querySelector('[md-theme=platform-bar]') || document.querySelector('.cfc-platform-bar-blue') || document.querySelector('.cfc-platform-bar-white.gm2-platform-bar');
+  return document.querySelector('[md-theme=platform-bar]') || document.querySelector('.cfc-platform-bar-blue') || document.querySelector('.cfc-platform-bar-white.gm2-platform-bar') || document.querySelector('.cfc-platform-bar-container');
 }
 
 function changeHeaderColor() {


### PR DESCRIPTION
Since recently the extension stopped working. It seems due to the fact that the container class changed names on Google's side.