### PR TITLE
Add FQDN for Google Cloud Workforce Identity SSO Console

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,8 @@
   "content_scripts": [
     {
       "matches": [
-        "https://console.cloud.google.com/*"
+        "https://console.cloud.google.com/*",
+        "https://console.cloud.google/*"
       ],
       "js": ["main.js"]
     }


### PR DESCRIPTION
# Why

When opening the Cloud Console via SSO using Workforce Identity, the Chrome extension shows an error "Can't Read or Change Site's Data".

# What

For SSO using Workforce Identity, Cloud Console is handled by the following FQDNs.

```
console.cloud.google
```

For more information, visit https://cloud.google.com/iam/docs/workforce-console-sso?#initiate-console.

Added "https://console.cloud.google/*" to matches in manifest.json.
